### PR TITLE
Add select all keybind

### DIFF
--- a/src/lib/components/CanvasRenderer.svelte
+++ b/src/lib/components/CanvasRenderer.svelte
@@ -621,6 +621,10 @@
 	on:pointermove={pointerMoveHandler}
 	on:keydown={(e) => {
 		if (e.target != document.body) return;
+		if (e.ctrlKey && e.key == "a") {
+			e.preventDefault()
+			selectedStore.set($projectFile.keyData);
+		}
 		if (e.key == "Escape") {
 			toolStore.set("select");
 		}


### PR DESCRIPTION
adds keybind ctrl a to select all keycaps and prevents it from selecting all text in the document