### PR TITLE
Add color variables to the properties panel & file format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
 			"version": "0.0.1-Alpha",
 			"dependencies": {
 				"@doodle3d/clipper-js": "^1.0.11",
+				"@floating-ui/core": "^1.6.4",
 				"chroma-js": "^2.4.2",
 				"paper": "^0.12.17",
 				"svelte-canvas": "^1.2.0",
+				"svelte-floating-ui": "^1.5.9",
 				"svelte-icons-pack": "^3.1.3",
 				"svg-path-parser": "^1.1.0",
 				"svg-round-corners": "^0.4.3"
@@ -421,6 +423,28 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
+			"integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.4"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
+			"integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.4"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
+			"integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
@@ -1801,6 +1825,15 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
+			}
+		},
+		"node_modules/svelte-floating-ui": {
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.9.tgz",
+			"integrity": "sha512-X5690AOuPlox+C2C4RvL6JAl/hDHEvwXXrUqWXYLN4L9ClMEZfZIfXYl8IMw6Mf7Hv9z8VjUKGsfN4IwxjDqSA==",
+			"dependencies": {
+				"@floating-ui/core": "^1.5.0",
+				"@floating-ui/dom": "^1.5.3"
 			}
 		},
 		"node_modules/svelte-hmr": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
 	"type": "module",
 	"dependencies": {
 		"@doodle3d/clipper-js": "^1.0.11",
+		"@floating-ui/core": "^1.6.4",
 		"chroma-js": "^2.4.2",
 		"paper": "^0.12.17",
 		"svelte-canvas": "^1.2.0",
+		"svelte-floating-ui": "^1.5.9",
 		"svelte-icons-pack": "^3.1.3",
 		"svg-path-parser": "^1.1.0",
 		"svg-round-corners": "^0.4.3"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "kle-silly-project",
+	"license": "GPL-3.0",
 	"version": "0.0.1-Alpha",
 	"private": true,
 	"scripts": {

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -17,7 +17,13 @@ declare global {
         }
         type FileData = {
             name: string,
+            variables: [ColorVariable] | ColorVariable[],
             keyData: [CapDataElement] | CapDataElement[]
+        }
+        type ColorVariable = {
+            id: string, 
+            displayName: string,
+            color: string
         }
     type CanvasRendererInput = {context: CanvasRenderingContext2D, width: number, height: number}
 }

--- a/src/lib/components/CanvasRenderer.svelte
+++ b/src/lib/components/CanvasRenderer.svelte
@@ -42,6 +42,7 @@
 	});
 
 	function generateGrid(ctx: CanvasRenderingContext2D) {
+		
 		let cornerSize = 5;
 		ctx.fillStyle = "#0004";
 		for (let x = 0; x < 4; x++) {

--- a/src/lib/components/CapLayer.svelte
+++ b/src/lib/components/CapLayer.svelte
@@ -5,7 +5,7 @@
 	import gorton from "$lib/styles/fonts/OpenGorton-Bold.otf";
 	import Astha from "$lib/styles/fonts/ASTHA-LATIN.otf";
 	import { onMount, onDestroy } from "svelte";
-	import { selectedStore, uiAccent } from "$lib";
+	import { parseCapColor, selectedStore, uiAccent } from "$lib";
 	export let capData: CapDataElement;
 	export let unitSize;
 	export let previewTextValue = "";
@@ -19,7 +19,7 @@
 	let h2 = capData.h2 || h;
 	let r = capData.r || 0;
 	let stepped = capData.stepped || false;
-	let textColor = capData.textColor || "black";
+	let textColor = parseCapColor(capData.textColor) || "black";
 	let legend = capData.legends || "";
 	let selected = false;
 	export let panX;
@@ -30,7 +30,7 @@
 	let capHighlightPadding = 11;
     let capHighlightCentered: Boolean = true;
     let fontLoaded = false;
-	let capColor = chroma(capData.color || "#969696");
+	let capColor = chroma(parseCapColor(capData.color) || "#969696");
 	let capDarken = capColor.darken(0.35);
 	let capEdge = capDarken.darken(0.5);
 
@@ -55,9 +55,9 @@
 		h2 = capData.h2 || h;
 	    r = capData.r || 0;
 		stepped = capData.stepped || false;
-		textColor = capData.textColor || "black";
+		textColor = parseCapColor(capData.textColor) || "black";
 		legend = capData.legends || "";
-		capColor = chroma(capData.color || "#969696");
+		capColor = chroma(parseCapColor(capData.color) || "#969696");
 		capDarken = capColor.darken(0.35);
 		capEdge = capDarken.darken(0.5);
 	}

--- a/src/lib/components/ColorVariable.svelte
+++ b/src/lib/components/ColorVariable.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { deleteVariable, updateVariableData } from "$lib";
+
+	export let variable: ColorVariable;
+
+	let color = variable.color;
+	let id = variable.id;
+	let name = variable.displayName;
+</script>
+
+<div class="color-input">
+	<div class="color-side">
+		<input
+			name="textColor"
+			type="color"
+			bind:value={color}
+			on:input={() => {
+				updateVariableData(id, null, color);
+			}}
+		/>
+		<div class="preview" style={`background: ${color}`}></div>
+	</div>
+    <div class="name-side">
+        <input type="text" bind:value={name}
+        on:input={() => {
+            updateVariableData(id, name, null);
+        }}
+        >
+    </div>
+    <button on:click={e => deleteVariable(id)}><i class="hi-x"></i></button>
+</div>
+
+<style>
+	input {
+		width: 100%;
+	}
+    .name-side {
+        min-width: 50%;
+        height: 30px;
+    }
+    .name-side input {
+        height: 30px;
+        border-radius: 0;
+		box-sizing: border-box;
+		outline: none;
+		border: none;
+        padding: 8px;
+		border-left: 1px solid var(--ui-transparent-outline);
+    }
+    
+	button {
+		width: 30px;
+		flex-basis: 30px;
+		height: 30px;
+		flex-shrink: 0;
+		border: none;
+		background: none;
+		padding: 0 !important;
+		border-radius: 0;
+		border-left: 1px solid var(--ui-transparent-outline);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		color: var(--secondary-text);
+        cursor: pointer;
+	}
+</style>

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -33,6 +33,7 @@
 		position: absolute;
 		bottom: 12px;
 		left: 12px;
+		user-select: none;
 	}
 	.secondary {
 		opacity: 0.5;
@@ -41,7 +42,7 @@
 		align-items: center;
 	}
 	.noclick {
-		pointer-events: none;
+		pointer-events: none !important;
 		display: flex;
 		gap: 8px;
 		align-items: center;

--- a/src/lib/components/PropertiesPanel.svelte
+++ b/src/lib/components/PropertiesPanel.svelte
@@ -5,8 +5,13 @@
 		projectFile,
 		propertyPanelStore,
 		alignCapsToGrid,
-		logData
+		logData,
+		parseCapColor,
+		getWhiteOrBlackFromColor,
+		createVariable,
+		variableDeletionStore,
 	} from "$lib";
+	import ColorVariable from "./ColorVariable.svelte";
 	function updateProperty(property: string, event: Event | null) {
 		if (!event?.target) return;
 		updateCapData(
@@ -23,7 +28,13 @@
 		if (property == "color")
 			capColor = (event.target as HTMLInputElement).value;
 	}
-	
+
+	function setColorToVariable(prop: string, val: string) {
+		updateCapData($selectedStore, prop, val, false, false);
+		if (prop == "textColor") textColor = val;
+		if (prop == "color") capColor = val;
+	}
+
 	let textColor = "";
 	let capColor = "";
 	$: {
@@ -36,7 +47,17 @@
 				? $selectedStore[$selectedStore.length - 1].textColor
 				: "";
 	}
+	let showTextColorVarPicker = false;
+	let showCapColorVarPicker = false;
+	function onwindowclick(e: MouseEvent) {
+		if ((e.target as HTMLElement).classList.contains("color-variable-button"))
+			return;
+		showTextColorVarPicker = false;
+		showCapColorVarPicker = false;
+	}
 </script>
+
+<svelte:window on:click={onwindowclick} />
 
 <div id="properties-panel" class="ui-floating-element">
 	<h1>Properties</h1>
@@ -170,30 +191,82 @@
 						<div class="input-stack">
 							<label for="capColor">Cap Color</label>
 							<div class="color-input">
-								<input
-									name="capColor"
-									type="color"
-									value={$selectedStore[$selectedStore.length - 1].color}
-									on:input={(e) => {
-										updateProperty("color", e);
-									}}
-								/>
-								<div class="preview" style={`background: ${capColor}`}></div>
+								<div class="color-side">
+									<input
+										name="capColor"
+										type="color"
+										value={parseCapColor(
+											$selectedStore[$selectedStore.length - 1].color
+										)}
+										on:input={(e) => {
+											updateProperty("color", e);
+										}}
+									/>
+									<div
+										class="preview"
+										style={`background: ${parseCapColor(capColor)}`}
+									></div>
+								</div>
+								<button
+									on:click={(e) =>
+										(showCapColorVarPicker = !showCapColorVarPicker)}
+									class={"color-variable-button " +
+										(capColor.startsWith("$") ? "variable-active" : "")}
+									><i class="hi-book-open"></i></button
+								>
 							</div>
+							{#if showCapColorVarPicker}
+								<div class="color-input-variable-picker">
+									{#each $projectFile.variables as variable}
+										<button
+											on:click={(e) =>
+												setColorToVariable("color", "$" + variable.id)}
+											style={`background: ${variable.color}; color: ${getWhiteOrBlackFromColor(variable.color)}`}
+											>{variable.displayName}</button
+										>
+									{/each}
+								</div>
+							{/if}
 						</div>
 						<div class="input-stack">
 							<label for="textColor">Text Color</label>
 							<div class="color-input">
-								<input
-									name="textColor"
-									type="color"
-									value={$selectedStore[$selectedStore.length - 1].textColor}
-									on:input={(e) => {
-										updateProperty("textColor", e);
-									}}
-								/>
-								<div class="preview" style={`background: ${textColor}`}></div>
+								<div class="color-side">
+									<input
+										name="textColor"
+										type="color"
+										value={parseCapColor(
+											$selectedStore[$selectedStore.length - 1].textColor
+										)}
+										on:input={(e) => {
+											updateProperty("textColor", e);
+										}}
+									/>
+									<div
+										class="preview"
+										style={`background: ${parseCapColor(textColor)}`}
+									></div>
+								</div>
+								<button
+									on:click={(e) =>
+										(showTextColorVarPicker = !showTextColorVarPicker)}
+									class={"color-variable-button " +
+										(textColor.startsWith("$") ? "variable-active" : "")}
+									><i class="hi-book-open"></i></button
+								>
 							</div>
+							{#if showTextColorVarPicker}
+								<div class="color-input-variable-picker">
+									{#each $projectFile.variables as variable}
+										<button
+											on:click={(e) =>
+												setColorToVariable("textColor", "$" + variable.id)}
+											style={`background: ${variable.color}; color: ${getWhiteOrBlackFromColor(variable.color)}`}
+											>{variable.displayName}</button
+										>
+									{/each}
+								</div>
+							{/if}
 						</div>
 					</div>
 				{/key}
@@ -203,6 +276,17 @@
 		{:else}
 			<p>No Cap Is Selected</p>
 		{/if}
+	</div>
+	<h1>Variables</h1>
+	<div class="button-grid">
+		{#key $variableDeletionStore}
+			{#each $projectFile.variables as variable}
+				<ColorVariable {variable}></ColorVariable>
+			{/each}
+		{/key}
+		<button class="shallow-button" on:click={createVariable}
+			><i class="hi-plus-large"></i></button
+		>
 	</div>
 	<h1>Actions</h1>
 	<div class="button-grid">
@@ -254,9 +338,32 @@
 		flex-direction: column;
 		gap: 3px;
 		margin-top: 12px;
+		position: relative;
 	}
 	label {
 		padding: 0 4px;
+	}
+	button.color-variable-button {
+		width: 30px;
+		flex-basis: 30px;
+		height: 30px;
+		flex-shrink: 0;
+		border: none;
+		background: none;
+		padding: 0 !important;
+		border-radius: 0;
+		border-left: 1px solid var(--ui-transparent-outline);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		color: var(--secondary-text);
+	}
+	button.color-variable-button i {
+		pointer-events: none;
+	}
+	button.variable-active {
+		color: white;
+		background: var(--accent);
 	}
 	button {
 		padding: 8px 12px;
@@ -271,38 +378,42 @@
 		flex-basis: 40%;
 		flex-grow: 1;
 	}
+
+	.shallow-button {
+		padding: 0;
+		background: none;
+		opacity: 0.75;
+	}
+	.shallow-button:hover {
+		background: var(--ui-element-background);
+		opacity: 1;
+	}
+
 	.button-grid {
 		display: flex;
 		justify-content: space-between;
 		gap: 8px;
 		flex-wrap: wrap;
 	}
-	input:hover,
-	button:hover {
-		background: var(--ui-light-gray);
-	}
-	.color-input {
-		position: relative;
-		width: 100%;
-		box-sizing: border-box;
-		outline: none;
-		border: none;
-		border-radius: 4px;
-		background: var(--ui-element-background);
-	}
-	input[type="color"] {
-		opacity: 0;
-	}
-	.color-input .preview {
+
+	.color-input-variable-picker {
 		position: absolute;
-		width: 100%;
-		height: 100%;
-		top: 0;
-		left: 0;
-		z-index: 1000;
-		pointer-events: none;
-		border-radius: 4px;
-		border: 1px solid white;
+		top: 56px;
+		right: 0;
+		z-index: 100000;
+		background: white;
+		border-radius: 10px;
 		border: 1px solid var(--ui-transparent-outline);
+		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.233);
+		padding: 6px;
+		display: flex;
+		gap: 4px;
+		flex-direction: column;
+		width: 150px;
+	}
+	.color-input-variable-picker button {
+		width: 100%;
+		text-wrap: nowrap;
+		overflow: hidden;
 	}
 </style>

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -11,6 +11,7 @@
     --ui-element-background: #efefef;
     --ui-transparent-outline: #c3c3c366;
     --accent: #7116f1;
+    --accent-light: #e6ddff;
 }
 
 * {

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -1,5 +1,5 @@
 @import url('./fonts/fonts.css');
-@import url('https://cdn.jsdelivr.net/gh/Hyperiooo/Hypericons@v0.7.6/fonts/hypericons.css');
+@import url('https://cdn.jsdelivr.net/gh/Hyperiooo/Hypericons@v0.7.9.2/fonts/hypericons.css');
 
 :root {
     --main-bg: rgb(244, 244, 244);
@@ -35,6 +35,7 @@ html {
     border-radius: 12px;
     position: absolute;
     box-shadow: 0 5px 7px 0 rgba(0, 0, 0, 0.068);
+    overflow: hidden;
 }
 h1, h2, h3 {
     color: var(--main-text);
@@ -78,4 +79,48 @@ canvas {
 
 .cursor-translate {
     cursor: move;
+}
+
+input:hover,
+button:hover {
+    background: var(--ui-light-gray);
+}
+input[type="color"] {
+    opacity: 0;
+}
+
+.color-input {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    outline: none;
+    border: none;
+    border-radius: 4px;
+    background: var(--ui-element-background);
+    border-radius: 4px;
+    border: 1px solid white;
+    border: 1px solid var(--ui-transparent-outline);
+    overflow: hidden;
+    display: flex;
+}
+.color-side {
+    position: relative;
+    width: 100%;
+    border-radius: 0;
+    box-sizing: border-box;
+    outline: none;
+    border: none;
+    height: 30px;
+}
+.color-side .preview {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    pointer-events: none;
+}
+.color-side input {
+    height: 30px;
 }

--- a/src/lib/template.json
+++ b/src/lib/template.json
@@ -1,5 +1,17 @@
 {
     "name": "Default Layout",
+    "variables": [
+        {
+            "id": "DACC",
+            "color": "#7116f1",
+            "displayName": "Accent Color"
+        },
+        {
+            "id": "DACCT",
+            "color": "#ffffff",
+            "displayName": "Accent Text"
+        }
+    ],
     "keyData": [
         {
             "legends": "Esc",
@@ -11,8 +23,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },

--- a/src/lib/template.json
+++ b/src/lib/template.json
@@ -3,7 +3,7 @@
     "variables": [
         {
             "id": "DACC",
-            "color": "#7116f1",
+            "color": "#8833ff",
             "displayName": "Accent Color"
         },
         {
@@ -608,8 +608,8 @@
             "y2": 0,
             "w2": 2.25,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },
@@ -1133,8 +1133,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },
@@ -1148,8 +1148,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },
@@ -1163,8 +1163,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },
@@ -1178,8 +1178,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 1,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         },
@@ -1568,8 +1568,8 @@
             "y2": 0,
             "w2": 1,
             "h2": 2,
-            "color": "#7116f1",
-            "textColor": "#ffffff",
+            "color": "$DACC",
+            "textColor": "$DACCT",
             "stepped": false,
             "r": 0
         }


### PR DESCRIPTION
Color variables are added, utilizing the `$` prefix to a properties value, which is followed by the ID of the variable to retrieve from. Currently, it only supports color variables, but in the future can be added to any other property using the same syntax.